### PR TITLE
Incorrect API response for leaves - fix

### DIFF
--- a/server/service/attendenceService.js
+++ b/server/service/attendenceService.js
@@ -47,7 +47,7 @@ const leaveTypeMap = {
 
 const writeLeaveToAttendence = (attendence, month, userId, leave) => {
   const m = moment(leave.startDate);
-  while(m.toDate() < leave.endDate) {
+  while(m.toDate() <= leave.endDate) {
     if (m.month() === month) {
       const leaveType = leaveTypeMap[leave.type] || leaveTypeMap['OTHER'];
       if (attendence[userId].days[m.date() - 1].leave) {


### PR DESCRIPTION
Modified the condition of the while cycle in method `writeLeaveToAttendence`.

The former condition returned false when it reached the last day of the leave, so the operator `<` was changed to `<=`.

Multiple cases were tested, with correct results.